### PR TITLE
Add expense tracking with categories and improve dashboard UI

### DIFF
--- a/lib/data/expense_repository.dart
+++ b/lib/data/expense_repository.dart
@@ -1,0 +1,18 @@
+import '../models/expense.dart';
+
+class ExpenseRepository {
+  ExpenseRepository._();
+
+  static final ExpenseRepository instance = ExpenseRepository._();
+
+  final List<Expense> _expenses = [];
+
+  List<Expense> get expenses => List.unmodifiable(_expenses);
+
+  double get total =>
+      _expenses.fold(0, (previousValue, element) => previousValue + element.amount);
+
+  void addExpense(Expense expense) {
+    _expenses.add(expense);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,20 +3,15 @@ import 'package:flutter/material.dart';
 import 'package:ai_exp_track/screens/loginscreen.dart';
 import 'package:ai_exp_track/screens/homescreen.dart';
 import 'package:ai_exp_track/screens/registerscreen.dart';
-// import 'package:ai_exp_track/screens/chatscreen.dart';
-// import 'package:ai_exp_track/screens/expensescreen.dart';
-// import 'package:ai_exp_track/screens/addexpensescreen.dart';
-// import 'package:ai_exp_track/screens/scanscreen.dart';
+import 'package:ai_exp_track/screens/expensescreen.dart';
+import 'package:ai_exp_track/screens/addexpensescreen.dart';
+import 'package:ai_exp_track/screens/chatbotscreen.dart';
 
 void main() async {
-  WidgetsFlutterBinding.ensureInitialized(); 
+  WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
-
-
   runApp(const MainApp());
 }
-
-
 
 class MainApp extends StatelessWidget {
   const MainApp({super.key});
@@ -45,8 +40,11 @@ class MainApp extends StatelessWidget {
       initialRoute: '/login',
       routes: {
         '/login': (context) => LoginScreen(),
-        '/home' : (context) => HomeScreen(),
+        '/home': (context) => const HomeScreen(),
         '/register': (context) => const RegisterScreen(),
+        '/expenses': (context) => const ExpenseScreen(),
+        '/add-expense': (context) => const AddExpenseScreen(),
+        '/chat': (context) => const ChatBotScreen(),
       },
     );
   }

--- a/lib/models/expense.dart
+++ b/lib/models/expense.dart
@@ -1,0 +1,13 @@
+class Expense {
+  final String title;
+  final double amount;
+  final String category;
+  final DateTime date;
+
+  Expense({
+    required this.title,
+    required this.amount,
+    required this.category,
+    DateTime? date,
+  }) : date = date ?? DateTime.now();
+}

--- a/lib/screens/addexpensescreen.dart
+++ b/lib/screens/addexpensescreen.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import '../data/expense_repository.dart';
+import '../models/expense.dart';
+
+class AddExpenseScreen extends StatefulWidget {
+  const AddExpenseScreen({super.key});
+
+  @override
+  State<AddExpenseScreen> createState() => _AddExpenseScreenState();
+}
+
+class _AddExpenseScreenState extends State<AddExpenseScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  final _categoryController = TextEditingController();
+  final _amountController = TextEditingController();
+  final _dateController = TextEditingController();
+  DateTime _selectedDate = DateTime.now();
+
+  @override
+  void initState() {
+    super.initState();
+    _dateController.text =
+        _selectedDate.toLocal().toString().split('.')[0];
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _categoryController.dispose();
+    _amountController.dispose();
+    _dateController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickDateTime() async {
+    final date = await showDatePicker(
+      context: context,
+      initialDate: _selectedDate,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+    );
+    if (date == null) return;
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(_selectedDate),
+    );
+    setState(() {
+      _selectedDate = DateTime(
+        date.year,
+        date.month,
+        date.day,
+        time?.hour ?? 0,
+        time?.minute ?? 0,
+      );
+      _dateController.text =
+          _selectedDate.toLocal().toString().split('.')[0];
+    });
+  }
+
+  void _saveExpense() {
+    if (_formKey.currentState!.validate()) {
+      final expense = Expense(
+        title: _titleController.text.trim(),
+        category: _categoryController.text.trim(),
+        amount: double.parse(_amountController.text.trim()),
+        date: _selectedDate,
+      );
+      ExpenseRepository.instance.addExpense(expense);
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Add Expense'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _titleController,
+                decoration: const InputDecoration(labelText: 'Title'),
+                validator: (value) =>
+                    value == null || value.isEmpty ? 'Enter a title' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _categoryController,
+                decoration: const InputDecoration(labelText: 'Category'),
+                validator: (value) =>
+                    value == null || value.isEmpty ? 'Enter a category' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _dateController,
+                readOnly: true,
+                decoration:
+                    const InputDecoration(labelText: 'Date & Time'),
+                onTap: _pickDateTime,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _amountController,
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(labelText: 'Amount'),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Enter an amount';
+                  }
+                  final amount = double.tryParse(value);
+                  if (amount == null) {
+                    return 'Enter a valid number';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _saveExpense,
+                  child: const Text('Save Expense'),
+                ),
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/chatbotscreen.dart
+++ b/lib/screens/chatbotscreen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class ChatBotScreen extends StatelessWidget {
+  const ChatBotScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Chat Assistant'),
+      ),
+      body: const Center(
+        child: Text('Chat feature coming soon'),
+      ),
+    );
+  }
+}

--- a/lib/screens/expensescreen.dart
+++ b/lib/screens/expensescreen.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import '../data/expense_repository.dart';
+
+class ExpenseScreen extends StatelessWidget {
+  const ExpenseScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final expenses = ExpenseRepository.instance.expenses;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Expenses'),
+      ),
+      body: expenses.isEmpty
+          ? const Center(child: Text('No expenses yet'))
+          : ListView.separated(
+              itemBuilder: (context, index) {
+                final expense = expenses[index];
+                return ListTile(
+                  title: Text(expense.title),
+                  subtitle: Text(
+                      '${expense.category} - \$${expense.amount.toStringAsFixed(2)} - ${expense.date.toLocal().toString().split('.')[0]}'),
+                );
+              },
+              separatorBuilder: (_, __) => const Divider(height: 0),
+              itemCount: expenses.length,
+            ),
+    );
+  }
+}

--- a/lib/screens/homescreen.dart
+++ b/lib/screens/homescreen.dart
@@ -1,13 +1,21 @@
-import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import '../data/expense_repository.dart';
+import 'addexpensescreen.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
 
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     final user = FirebaseAuth.instance.currentUser;
     final email = user?.email ?? 'User';
+    final total = ExpenseRepository.instance.total;
 
     return Scaffold(
       backgroundColor: const Color(0xFFF6F6F6),
@@ -24,7 +32,9 @@ class HomeScreen extends StatelessWidget {
             icon: const Icon(Icons.logout, color: Colors.black),
             onPressed: () async {
               await FirebaseAuth.instance.signOut();
-              Navigator.pushReplacementNamed(context, '/login');
+              if (context.mounted) {
+                Navigator.pushReplacementNamed(context, '/login');
+              }
             },
           )
         ],
@@ -34,6 +44,31 @@ class HomeScreen extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            Card(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Welcome, $email',
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Total Spending: \$${total.toStringAsFixed(2)}',
+                      style: const TextStyle(fontSize: 16),
+                    ),
+                  ],
+                ),
+              ),
+            ),
             const SizedBox(height: 24),
             _buildActionCard(
               context,
@@ -52,8 +87,13 @@ class HomeScreen extends StatelessWidget {
             SizedBox(
               width: double.infinity,
               child: ElevatedButton.icon(
-                onPressed: () {
-                  Navigator.pushNamed(context, '/add-expense');
+                onPressed: () async {
+                  await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const AddExpenseScreen()),
+                  );
+                  setState(() {});
                 },
                 icon: const Icon(Icons.add),
                 label: const Text('Add Expense'),
@@ -76,7 +116,10 @@ class HomeScreen extends StatelessWidget {
   Widget _buildActionCard(BuildContext context,
       {required IconData icon, required String label, required String route}) {
     return InkWell(
-      onTap: () => Navigator.pushNamed(context, route),
+      onTap: () async {
+        await Navigator.pushNamed(context, route);
+        setState(() {});
+      },
       borderRadius: BorderRadius.circular(20),
       child: Ink(
         decoration: BoxDecoration(
@@ -96,8 +139,8 @@ class HomeScreen extends StatelessWidget {
           children: [
             Container(
               padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: const Color(0xFFF2F1FF),
+              decoration: const BoxDecoration(
+                color: Color(0xFFF2F1FF),
                 shape: BoxShape.circle,
               ),
               child: Icon(icon, color: const Color(0xFF7B61FF), size: 28),


### PR DESCRIPTION
## Summary
- implement simple expense model and repository
- add screens for adding and viewing expenses and link them into dashboard
- refresh home screen with a greeting card and expense summary
- add category field to expenses and timestamp support with optional manual date/time input
- fix Add Expense button navigation by using MaterialPageRoute to push AddExpenseScreen

## Testing
- `dart format lib/screens/homescreen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68961a47a518832d910d5f6eaf3348c4