### PR TITLE
Dispose controllers and clean imports

### DIFF
--- a/lib/screens/homescreen.dart
+++ b/lib/screens/homescreen.dart
@@ -2,7 +2,6 @@ import 'package:ai_exp_track/screens/addexpensescreen.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import '../data/expense_repository.dart';
-import 'addexpensescreen.dart';
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
 

--- a/lib/screens/loginscreen.dart
+++ b/lib/screens/loginscreen.dart
@@ -58,6 +58,13 @@ class _LoginScreenState extends State<LoginScreen> {
 
 
   @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Container(

--- a/lib/screens/registerscreen.dart
+++ b/lib/screens/registerscreen.dart
@@ -41,6 +41,13 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
 
   @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Container(


### PR DESCRIPTION
## Summary
- dispose login and registration controllers to avoid memory leaks
- remove redundant HomeScreen import

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689629d50a28832dacc97ecf5d91dcd5